### PR TITLE
Update funding information in FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,3 @@
-github: daveio
-ko_fi: daveio
-custom: saythanks.io/to/daveio
+github: synmux
+ko_fi: synmux
+custom: saythanks.io/to/synmux


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update FUNDING.yml to reference synmux accounts instead of daveio for sponsorship links.